### PR TITLE
#701 redirect user to / on login

### DIFF
--- a/codalab/codalab/settings/base.py
+++ b/codalab/codalab/settings/base.py
@@ -241,7 +241,7 @@ class Base(Settings):
     SERVER_EMAIL = 'info@codalab.org'
 
     # Authentication configuration
-    LOGIN_REDIRECT_URL = '/my'
+    LOGIN_REDIRECT_URL = '/'
     ANONYMOUS_USER_ID = -1
     ACCOUNT_AUTHENTICATION_METHOD='username_email'
     ACCOUNT_EMAIL_REQUIRED=True


### PR DESCRIPTION
In the future, maybe we can track whether a user spends more time in worksheets or competitions, or remember the last page they were on and redirect them back to it when they log back in.