### PR TITLE
don't create empty user worksheet by default

### DIFF
--- a/codalab/apps/authenz/views.py
+++ b/codalab/apps/authenz/views.py
@@ -36,26 +36,27 @@ def new_user_signup(sender, **kwargs):
     """
     user = kwargs['user']
     get_or_create_cli_client(user)
-    if len(settings.BUNDLE_SERVICE_URL) > 0:
-        from apps.web.bundles import BundleService
-        service = BundleService(user)
-        try:
-            #clean up there name and make sure nothing sneaks in
-            ws_name = smart_str(user.username)
-            if "@" in ws_name:
-                ws_name = ws_name.split('@')[0]
-            rx = re.compile('\W+')
-            ws_name = rx.sub('', ws_name).strip()
-            uuid = service.create_worksheet(ws_name)
-        except Exception as e:
-            logging.error("create_default_worksheet")
-            logging.error(smart_str(e))
-            logging.error('Error Creating default worksheet for new user')
-            logging.debug('-------------------------')
-            tb = traceback.format_exc()
-            logging.error(tb)
-            logging.debug('-------------------------')
-            raise e
+    # Don't create a worksheet by default.
+    #if len(settings.BUNDLE_SERVICE_URL) > 0:
+    #    from apps.web.bundles import BundleService
+    #    service = BundleService(user)
+    #    try:
+    #        #clean up there name and make sure nothing sneaks in
+    #        ws_name = smart_str(user.username)
+    #        if "@" in ws_name:
+    #            ws_name = ws_name.split('@')[0]
+    #        rx = re.compile('\W+')
+    #        ws_name = rx.sub('', ws_name).strip()
+    #        uuid = service.create_worksheet(ws_name)
+    #    except Exception as e:
+    #        logging.error("create_default_worksheet")
+    #        logging.error(smart_str(e))
+    #        logging.error('Error Creating default worksheet for new user')
+    #        logging.debug('-------------------------')
+    #        tb = traceback.format_exc()
+    #        logging.error(tb)
+    #        logging.debug('-------------------------')
+    #        raise e
 
 @receiver(user_logged_in)
 def on_user_logged_in(sender, **kwargs):

--- a/codalab/apps/web/static/js/search/ws_actions.js
+++ b/codalab/apps/web/static/js/search/ws_actions.js
@@ -64,7 +64,7 @@ var WorksheetActions =  function() {
             'new': {
                 helpText: formatHelp('new <name>', 'create new worksheet with given name'),
                 minimumInputLength: 0,
-                edit_enabled: true,
+                edit_enabled: false,
                 searchChoice: function(input, term){
                     return {
                         id: term,
@@ -227,6 +227,7 @@ var WorksheetActions =  function() {
                     }
                 }, // end of executefn
             }, // end of upload
+
             'run': {
                 // TODO: support run targets
                 helpText: formatHelp('run <key>:<bundle> ... \'<command>\'', 'create a run bundle'),
@@ -325,6 +326,7 @@ var WorksheetActions =  function() {
                     });
                 },
             }, // end of run
+
             'cl': {
                 helpText: formatHelp('cl <command>', 'run CLI command'),
                 minimumInputLength: 0,

--- a/codalab/apps/web/templates/account/login.html
+++ b/codalab/apps/web/templates/account/login.html
@@ -63,8 +63,8 @@
 		    {% endif %}
 		    <button class="btn btn-primary margin-top" type="submit">{% trans "Sign In" %}</button>
 	    </form>
-	    <p class="pad-top"><a href="{{ signup_url }}">Sign up</a> if you don't have an account.<br />
-		<a href="../password/reset/">Did you forget your password?</a></p>
+        <p class="pad-top"><a href="{{ signup_url }}">Sign up for a new account</a></p>
+		<a href="../password/reset/">Forgot your password?</a></p>
     </div>
 </div>
 {% endblock %}

--- a/codalab/apps/web/templates/account/password_reset.html
+++ b/codalab/apps/web/templates/account/password_reset.html
@@ -11,7 +11,7 @@
 {% if user.is_authenticated %}
     {% include "account/snippets/already_logged_in.html" %}
 {% endif %}
-<p>{% trans "Forgotten your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}</p>
+<p>{% trans "Forgot your password? Enter your e-mail address below, and we'll send you an e-mail allowing you to reset it." %}</p>
 <div class="row">
 
     <div class="col-md-6">
@@ -24,5 +24,4 @@
         </form>
     </div>
 </div>
-<p class="pad-top">{% blocktrans %}Please use the Contact Us link at the bottom of the page to get in touch if you have any trouble resetting your password.{% endblocktrans %}</p>
 {% endblock %}

--- a/codalab/apps/web/templates/account/signup.html
+++ b/codalab/apps/web/templates/account/signup.html
@@ -26,7 +26,7 @@
 
             <div class="form-group">
                 <label for="id_username">*Username:</label>
-                <input id="id_username" class="form-control" name="username" placeholder="Username" type="text" value="{{ form.username.value|default_if_none:"" }}">
+                <input id="id_username" class="form-control" name="username" autofocus placeholder="Username" type="text" value="{{ form.username.value|default_if_none:"" }}">
             </div>
             <div class="form-group">
                 <label for="id_email">*E-mail:</label>

--- a/codalab/apps/web/templates/web/my/settings.html
+++ b/codalab/apps/web/templates/web/my/settings.html
@@ -3,8 +3,8 @@
 {% load codalab_tags %}
 {% load tz %}
 
-{% block page_title %}Settings{% endblock page_title %}
-{% block head_title %}Settings{% endblock %}
+{% block page_title %}User Settings{% endblock page_title %}
+{% block head_title %}User Settings{% endblock %}
 
 {% block extra_head %}
 {# include extra JS stuff here #}
@@ -35,7 +35,7 @@
 
     <div class="row">
         <div class="col-sm-12">
-            <h4>My Account {% if user.is_staff %}<span class="label label-info">Staff</span>{% endif %}{% if user.is_superuser %} <span class="label label-success">Admin</span>{% endif %}</h4>
+            <h4>Basic settings {% if user.is_staff %}<span class="label label-info">Staff</span>{% endif %}{% if user.is_superuser %} <span class="label label-success">Admin</span>{% endif %}</h4>
             <table class="table table-striped account">
                 <tbody>
                     <tr>
@@ -51,7 +51,7 @@
                         <td>{{ user.email }}</td>
                     </tr>
                     <tr>
-                        <th>User since</th>
+                        <th>Date joined</th>
                         <td>{{ user.date_joined }}</td>
                     </tr>
                 </tbody>
@@ -82,7 +82,7 @@
     <div class="row">
         <div class="col-sm-12">
 
-            <h4>My subscription settings</h4>
+            <h4>Competition settings</h4>
 
             <table class="table table-striped subscriptions">
                 <tbody>


### PR DESCRIPTION
This way, when people sign up for competitions, you don't get an empty worksheet.  People have to explicitly create their own worksheet or use the CLI.

Also: some cosmetic changes to setting/login pages.