### PR TITLE
Edited worksheet table CSS

### DIFF
--- a/codalab/apps/web/static/css/imports.css
+++ b/codalab/apps/web/static/css/imports.css
@@ -7995,6 +7995,31 @@ fieldset[disabled] #worksheet_content .header-row .controls .edit-features .btn-
   font-size: 14px;
   border-width: 2px;
   border-color: white;
+  white-space: nowrap;
+  max-width: 25em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+#worksheet_content .type-table table > thead > tr > th:hover,
+#worksheet_content .type-record table > thead > tr > th:hover,
+#worksheet_content .type-search table > thead > tr > th:hover,
+#worksheet_content .type-table table > tbody > tr > th:hover,
+#worksheet_content .type-record table > tbody > tr > th:hover,
+#worksheet_content .type-search table > tbody > tr > th:hover,
+#worksheet_content .type-table table > tfoot > tr > th:hover,
+#worksheet_content .type-record table > tfoot > tr > th:hover,
+#worksheet_content .type-search table > tfoot > tr > th:hover,
+#worksheet_content .type-table table > thead > tr > td:hover,
+#worksheet_content .type-record table > thead > tr > td:hover,
+#worksheet_content .type-search table > thead > tr > td:hover,
+#worksheet_content .type-table table > tbody > tr > td:hover,
+#worksheet_content .type-record table > tbody > tr > td:hover,
+#worksheet_content .type-search table > tbody > tr > td:hover,
+#worksheet_content .type-table table > tfoot > tr > td:hover,
+#worksheet_content .type-record table > tfoot > tr > td:hover,
+#worksheet_content .type-search table > tfoot > tr > td:hover {
+  white-space: normal;
+  overflow: auto;
 }
 #worksheet_content .type-table table > thead > tr > th a.bundle-link,
 #worksheet_content .type-record table > thead > tr > th a.bundle-link,
@@ -8015,6 +8040,29 @@ fieldset[disabled] #worksheet_content .header-row .controls .edit-features .btn-
 #worksheet_content .type-record table > tfoot > tr > td a.bundle-link,
 #worksheet_content .type-search table > tfoot > tr > td a.bundle-link {
   font-weight: bold;
+}
+#worksheet_content .type-table table > thead > tr > th.table-column-_7C,
+#worksheet_content .type-record table > thead > tr > th.table-column-_7C,
+#worksheet_content .type-search table > thead > tr > th.table-column-_7C,
+#worksheet_content .type-table table > tbody > tr > th.table-column-_7C,
+#worksheet_content .type-record table > tbody > tr > th.table-column-_7C,
+#worksheet_content .type-search table > tbody > tr > th.table-column-_7C,
+#worksheet_content .type-table table > tfoot > tr > th.table-column-_7C,
+#worksheet_content .type-record table > tfoot > tr > th.table-column-_7C,
+#worksheet_content .type-search table > tfoot > tr > th.table-column-_7C,
+#worksheet_content .type-table table > thead > tr > td.table-column-_7C,
+#worksheet_content .type-record table > thead > tr > td.table-column-_7C,
+#worksheet_content .type-search table > thead > tr > td.table-column-_7C,
+#worksheet_content .type-table table > tbody > tr > td.table-column-_7C,
+#worksheet_content .type-record table > tbody > tr > td.table-column-_7C,
+#worksheet_content .type-search table > tbody > tr > td.table-column-_7C,
+#worksheet_content .type-table table > tfoot > tr > td.table-column-_7C,
+#worksheet_content .type-record table > tfoot > tr > td.table-column-_7C,
+#worksheet_content .type-search table > tfoot > tr > td.table-column-_7C {
+  background-color: #AAA;
+  color: #AAA;
+  width: 3px;
+  padding: 0;
 }
 #worksheet_content .type-table table > thead > tr > th,
 #worksheet_content .type-record table > thead > tr > th,

--- a/codalab/apps/web/static/css/imports.css
+++ b/codalab/apps/web/static/css/imports.css
@@ -7499,6 +7499,9 @@ input[type="checkbox"] {
 #worksheet.search-hidden .ws-search {
   top: -7px;
 }
+#worksheet > .container {
+  width: auto;
+}
 #worksheet_content {
   display: none;
   margin-top: 12px;
@@ -7842,6 +7845,7 @@ fieldset[disabled] #worksheet_content .header-row .controls .edit-features .btn-
   max-width: 100%;
   margin-bottom: 25px;
   border: 1px solid #dddddd;
+  width: auto;
   border-width: 2px;
   border-color: white;
   margin-bottom: 0;
@@ -8059,7 +8063,7 @@ fieldset[disabled] #worksheet_content .header-row .controls .edit-features .btn-
 #worksheet_content .type-table table > tfoot > tr > td.table-column-_7C,
 #worksheet_content .type-record table > tfoot > tr > td.table-column-_7C,
 #worksheet_content .type-search table > tfoot > tr > td.table-column-_7C {
-  background-color: #AAA;
+  background-color: #AAA !important;
   color: #AAA;
   width: 3px;
   padding: 0;

--- a/codalab/apps/web/static/js/worksheet/table_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/table_bundle_interface.js
@@ -236,9 +236,12 @@ var TableBundle = React.createClass({
         var className = 'table ' + (focused ? 'focused ' : '');
         var bundle_info = item.bundle_info;
         var header_items = item.interpreted[0];
+        var column_classes = header_items.map(function(item, index) {
+            return 'table-column-' + encodeURIComponent(item).replace("%", "_").replace(/[^-_A-Za-z0-9]/g, "_");
+        });
         var header_html = header_items.map(function(item, index) {
-                return <th key={index}> {item} </th>;
-            });
+            return <th key={index} className={column_classes[index]}>{item}</th>;
+        });
         var focusIndex = this.state.rowFocusIndex;
         var row_items = item.interpreted[1];
         var body_rows_html = row_items.map(function(row_item, index) {
@@ -253,6 +256,7 @@ var TableBundle = React.createClass({
                             focused={rowFocused}
                             bundleURL={bundle_url}
                             headerItems={header_items}
+                            columnClasses={column_classes}
                             canEdit={canEdit}
                             checkboxEnabled={focused}
                             handleClick={self.focusOnRow}
@@ -294,19 +298,20 @@ var TableRow = React.createClass({
         var focusedClass = this.props.focused ? 'focused' : '';
         var row_item = this.props.item;
         var header_items = this.props.headerItems;
+        var column_classes = this.props.columnClasses;
         var bundle_url = this.props.bundleURL;
         var checkbox = this.props.canEdit ? <td className="td-checkbox"><input type="checkbox" onChange={this.toggleChecked} checked={this.state.checked} disabled={!this.props.checkboxEnabled} /></td> : null;
         var row_cells = this.props.headerItems.map(function(header_key, index){
             if(index == 0){
                 return (
-                    <td key={index}>
+                    <td key={index} className={column_classes[index]}>
                         <a href={bundle_url} className="bundle-link" target="_blank">
                             {row_item[header_key]}
                         </a>
                     </td>
                 )
             } else {
-                return <td key={index}> {row_item[header_key]}</td>
+                return <td key={index} className={column_classes[index]}>{row_item[header_key]}</td>
             }
         });
         return (

--- a/codalab/apps/web/static/less/worksheets.less
+++ b/codalab/apps/web/static/less/worksheets.less
@@ -265,8 +265,22 @@
                   font-size:@font-size-med;
                   border-width:2px;
                   border-color:white;
+                  white-space:nowrap;
+                  max-width:25em;
+                  overflow:hidden;
+                  text-overflow:ellipsis;
+                  &:hover {
+                     white-space:normal;
+                     overflow:auto;
+                  }
                   a.bundle-link {
                      font-weight:bold;
+                  }
+                  &.table-column-_7C {
+                     background-color:#AAA;
+                     color:#AAA;
+                     width:3px;
+                     padding:0
                   }
                }
             }

--- a/codalab/apps/web/static/less/worksheets.less
+++ b/codalab/apps/web/static/less/worksheets.less
@@ -54,6 +54,9 @@
          top:-7px;
       }
    }
+   > .container {
+     width:auto;
+   }
 }
 #worksheet_content {
    display:none;
@@ -252,6 +255,7 @@
          .table;
          .table-bordered;
          .table-striped;
+         width:auto;
          border-width:2px;
          border-color:white;
          margin-bottom:0;
@@ -277,10 +281,10 @@
                      font-weight:bold;
                   }
                   &.table-column-_7C {
-                     background-color:#AAA;
+                     background-color:#AAA !important;
                      color:#AAA;
                      width:3px;
-                     padding:0
+                     padding:0;
                   }
                }
             }


### PR DESCRIPTION
This patch edits the CSS of the worksheet tables:

* Long cell contents are cut off but can be displayed by hovering the cursor on the cell.
* Added class names to cells to make styling easier. For example, a person with GreaseMonkey / TamperMonkey can add `.table-column-acc { color: red; }` to the personal CSS file to make the "acc" column text red.
* Column separator: If the column name is "|" (i.e., by putting `@add |` in the table schema), then a gray column separator is created