### PR TITLE
Improved coopetition logging

### DIFF
--- a/codalab/apps/web/models.py
+++ b/codalab/apps/web/models.py
@@ -470,7 +470,7 @@ def submission_history_file_name(instance, filename="history.txt"):
 def submission_scores_file_name(instance, filename="scores.txt"):
     return os.path.join(submission_root(instance), filename)
 
-def submission_coopetition_file_name(instance, filename="coopetition.txt"):
+def submission_coopetition_file_name(instance, filename="coopetition.zip"):
     return os.path.join(submission_root(instance), filename)
 
 def submission_runfile_name(instance, filename="run.txt"):


### PR DESCRIPTION
Resolves issue #1073 

@lr292358 requested improvements:
- [x] Submissions number
- [x] access to previous rounds (to access e.g. the final ranking). Can be just an access to a log in 2 files, like phase_0_log, phase_1_log
- [ ] ~~If submission fails, it is not included in the log~~ This was intended, we can't get scores/likes/etc for failed submission.....?
- [x] Add dislikes to log