### PR TITLE
Small fixes before production push

### DIFF
--- a/codalab/apps/web/templates/web/competitions/_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_results_page.html
@@ -21,6 +21,9 @@
         {% else %}
             <p>None</p>
         {% endif %}
+
+        <p><b>Max submissions per day: </b> {{ phase.max_submissions_per_day }}</p>
+        <p><b>Max submissions total: </b> {{ phase.max_submissions }}</p>
     </div>
     {% if groups|length > 0 %}
         <a class="icon-excel btn btn-default" href="/competitions/{{phase.competition.id}}/results/{{phase.id}}/data">Download CSV</a>

--- a/codalab/apps/web/templates/web/competitions/_submit_results_page.html
+++ b/codalab/apps/web/templates/web/competitions/_submit_results_page.html
@@ -20,6 +20,9 @@
         {% else %}
             <p>None</p>
         {% endif %}
+
+        <p><b>Max submissions per day: </b> {{ phase.max_submissions_per_day }}</p>
+        <p><b>Max submissions total: </b> {{ phase.max_submissions }}</p>
     </div>
 
     {% if phase.is_active %}

--- a/codalab/apps/web/templates/web/my/submissions.html
+++ b/codalab/apps/web/templates/web/my/submissions.html
@@ -25,6 +25,8 @@
     {% else %}
         <p>None</p>
     {% endif %}
+    <p><b>Max submissions per day: </b> {{ phase.max_submissions_per_day }}</p>
+    <p><b>Max submissions total: </b> {{ phase.max_submissions }}</p>
 
     <h4>Submissions</h4>
     {% if submission_info_list|length > 0 %}

--- a/codalab/apps/web/tests/test_competition_secret_key.py
+++ b/codalab/apps/web/tests/test_competition_secret_key.py
@@ -45,3 +45,8 @@ class CompetitionSecretKey(TestCase):
         self.competition.save()
         resp = self.client.get(reverse("competitions:view", kwargs={"pk": self.competition.pk}))
         self.assertEquals(resp.status_code, 200)
+
+    def test_competition_view_unpublished_returns_200_for_participant(self):
+        self.client.login(username="participant", password="pass")
+        resp = self.client.get(reverse("competitions:view", kwargs={"pk": self.competition.pk}))
+        self.assertEquals(resp.status_code, 200)

--- a/codalab/apps/web/tests/test_competition_secret_key.py
+++ b/codalab/apps/web/tests/test_competition_secret_key.py
@@ -20,6 +20,13 @@ class CompetitionSecretKey(TestCase):
             modified_by=self.organizer_user,
             published=False
         )
+        self.competition.participants.add(
+            CompetitionParticipant.objects.create(
+                competition=self.competition,
+                user=self.participant_user,
+                status=ParticipantStatus.objects.get_or_create(name='approved', codename=ParticipantStatus.APPROVED)[0]
+            )
+        )
 
     def test_competition_view_unpublished_returns_404_for_non_creator(self):
         resp = self.client.get(reverse("competitions:view", kwargs={"pk": self.competition.pk}))

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -314,7 +314,7 @@ class CompetitionDetailView(DetailView):
     def get(self, request, *args, **kwargs):
         competition = self.get_object()
         secret_key = request.GET.get("secret_key", None)
-        if competition.creator != request.user and request.user not in competition.admins.all():
+        if competition.creator != request.user and request.user not in competition.admins.all() and request.user not in competition.participants.all():
             if not competition.published and competition.secret_key != secret_key:
                 return HttpResponse(status=404)
         # FIXME: handles legacy problem with missing post_save signal for forums, creates forum if it

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -314,9 +314,12 @@ class CompetitionDetailView(DetailView):
     def get(self, request, *args, **kwargs):
         competition = self.get_object()
         secret_key = request.GET.get("secret_key", None)
-        if competition.creator != request.user and request.user not in competition.admins.all() and request.user not in competition.participants.all():
-            if not competition.published and competition.secret_key != secret_key:
-                return HttpResponse(status=404)
+        if competition.creator != request.user and request.user not in competition.admins.all():
+            # user may not be logged in, so grab PK if we can, to check if they are a participant
+            user_pk = request.user.pk or -1
+            if not competition.participants.filter(user=user_pk).exists():
+                if not competition.published and competition.secret_key != secret_key:
+                    return HttpResponse(status=404)
         # FIXME: handles legacy problem with missing post_save signal for forums, creates forum if it
         # does not exist for this competition. should be removed eventually.
         if not hasattr(competition, 'forum'):


### PR DESCRIPTION
Resolves #1139 before production push

### Tasks
- [ ] #1142 predict outputs swapped
- [x] #1145 display max # of subs
- [x] #1095 secret key not required for participants