### PR TITLE
issue #1242 fix: non existent file directives

### DIFF
--- a/codalab/apps/web/bundles.py
+++ b/codalab/apps/web/bundles.py
@@ -121,10 +121,10 @@ if len(settings.BUNDLE_SERVICE_URL) > 0:
                 for item in worksheet_info['items']:
                     if item['mode'] in ['html', 'contents']:
                         # item['name'] in ['stdout', 'stderr']
-                        try:
-                            item['interpreted'] = map(base64.b64decode, item['interpreted'])
-                        except Exception, e:
+                        if item['interpreted'] is None:
                             item['interpreted'] = ['MISSING']
+                        else:
+                            item['interpreted'] = map(base64.b64decode, item['interpreted'])
                     elif item['mode'] == 'table':
                         # some of the contents of item['interpreted'] may be None if the associated files don't exist yet. Replace them with 'MISSING'.
                         for row_map in item['interpreted'][1]:

--- a/codalab/apps/web/bundles.py
+++ b/codalab/apps/web/bundles.py
@@ -121,7 +121,16 @@ if len(settings.BUNDLE_SERVICE_URL) > 0:
                 for item in worksheet_info['items']:
                     if item['mode'] in ['html', 'contents']:
                         # item['name'] in ['stdout', 'stderr']
-                        item['interpreted'] = map(base64.b64decode, item['interpreted'])
+                        try:
+                            item['interpreted'] = map(base64.b64decode, item['interpreted'])
+                        except Exception, e:
+                            item['interpreted'] = ['MISSING']
+                    elif item['mode'] == 'table':
+                        # some of the contents of item['interpreted'] may be None if the associated files don't exist yet. Replace them with 'MISSING'.
+                        for row_map in item['interpreted'][1]:
+                            for k, v in row_map.iteritems():
+                                if v is None:
+                                    row_map[k] = 'MISSING'
                     elif 'bundle_info' in item:
                         for bundle_info in item['bundle_info']:
                             try:


### PR DESCRIPTION
### Testing

#### Manual Testing

For testing, the following worksheet was used:

```
***display table directive***

% schema s1
% add uuid
% add name
% add output /output
% display table s1
[dataset graph-1.txt]{0x440cfb819ef5412d90bc6e482eef79f1}
[dataset graph-2.txt]{0x86e03564a45d40d6a802482f87e47256}
[run topological-sort-run-graph-1 -- :topological-sort.py,input:graph-1.txt : python topological-sort.py < input > output]{0xa3817866bf2c4aeeb5f516546270b105}

% schema s2
% add uuid
% add output-1 /output-1
% display table s2
[run topological-sort-run-graph-1 -- :topological-sort.py,input:graph-1.txt : python topological-sort.py < input > output]{0xa3817866bf2c4aeeb5f516546270b105}


***display content directive***

% display contents /output
[dataset graph-2.txt]{0x86e03564a45d40d6a802482f87e47256}

% display contents /output
[run topological-sort-run-graph-1 -- :topological-sort.py,input:graph-1.txt : python topological-sort.py < input > output]{0xa3817866bf2c4aeeb5f516546270b105}

```

Before, when missing files were displayed using the `display contents /file` directive, an internal 500 error was thrown. 
![image](https://cloud.githubusercontent.com/assets/5567951/9625117/356120fe-5108-11e5-82a2-a9991c1dd33b.png)

Also, when a column, associated to a file that was not present, was added to table, '' (empty string corresponding to None) was shown in that column. 

![image](https://cloud.githubusercontent.com/assets/5567951/9625200/f8e5b2ec-5108-11e5-9d47-ac853befd7a1.png)

NOTE: For the above screenshot, the following lines were removed from the worksheet to avoid getting the 500 error.
```
% display contents /output
[dataset graph-2.txt]{0x86e03564a45d40d6a802482f87e47256}
```
Now, when `display content /file` is used to display a non-existent file, 'MISSING' is shown. The same applies for table columns which are associated to files that do not yet exist.

Here is a screenshot showing the changes:
![image](https://cloud.githubusercontent.com/assets/5567951/9625300/e8bced44-5109-11e5-9057-3c06aa55ac68.png)