### PR TITLE
issue #1275 and #1250

### DIFF
--- a/codalab/apps/api/views/worksheet_views.py
+++ b/codalab/apps/api/views/worksheet_views.py
@@ -356,6 +356,12 @@ class BundleInfoApi(views.APIView):
                     new_metadata['architectures'] = architectures
 
                 # update and return
+                # json load only gives string, convert them into needed type
+                new_metadata['request_cpus'] = int(new_metadata['request_cpus']);
+                new_metadata['request_gpus'] = int(new_metadata['request_gpus']);
+                new_metadata['request_priority'] = int(new_metadata['request_priority']);
+                new_metadata['actions'] = new_metadata['actions'].split();
+                new_metadata['exitcode'] = int(new_metadata['exitcode']);
                 print new_metadata
                 service.update_bundle_metadata(uuid, new_metadata)
                 bundle_info = service.get_bundle_info(uuid)

--- a/codalab/apps/web/bundles.py
+++ b/codalab/apps/web/bundles.py
@@ -307,12 +307,6 @@ if len(settings.BUNDLE_SERVICE_URL) > 0:
             return 500
 
         def update_bundle_metadata(self, uuid, new_metadata):
-            # json load only gives string, convert them into needed type
-            new_metadata['request_cpus'] = int(new_metadata['request_cpus']);
-            new_metadata['request_gpus'] = int(new_metadata['request_gpus']);
-            new_metadata['request_priority'] = int(new_metadata['request_priority']);
-            new_metadata['actions'] = new_metadata['actions'].split();
-            new_metadata['exitcode'] = int(new_metadata['exitcode']);
             self.client.update_bundle_metadata(uuid, new_metadata)
             return
 

--- a/codalab/apps/web/static/css/imports.css
+++ b/codalab/apps/web/static/css/imports.css
@@ -1351,7 +1351,9 @@ kbd kbd {
 }
 pre {
   display: block;
-  padding: 12px;
+  padding-top: 12px;
+  padding-left: 3px;
+  text-indent: 9px;  // so that there is no extra space and padding is the same
   margin: 0 0 12.5px;
   font-size: 15px;
   line-height: 1.6;


### PR DESCRIPTION
Issue #1275:
Move conversion from `bundles.py` to `worksheet_views.py`.

Issue #1250:
Manually add indentation at the front end.
Before:
![screenshot from 2015-09-25 22 13 33](https://cloud.githubusercontent.com/assets/6948032/10115378/ed4ffc1c-63d2-11e5-94cb-991d0211daf1.png)

After:
![screenshot from 2015-09-25 22 12 02](https://cloud.githubusercontent.com/assets/6948032/10115377/e8281d0a-63d2-11e5-8fcb-66b8ebdaae9e.png)
