### PR TITLE
Fix#1242 non existent file

### DIFF
--- a/codalab/apps/web/bundles.py
+++ b/codalab/apps/web/bundles.py
@@ -141,7 +141,10 @@ if len(settings.BUNDLE_SERVICE_URL) > 0:
                 for item in worksheet_info['items']:
                     if item['mode'] in ['html', 'contents']:
                         # item['name'] in ['stdout', 'stderr']
-                        item['interpreted'] = map(base64.b64decode, item['interpreted'])
+                        if item['interpreted'] is None:
+                            item['interpreted'] = ['MISSING']
+                        else:
+                            map(base64.b64decode, item['interpreted'])
                     elif item['mode'] == 'table':
                         for row_map in item['interpreted'][1]:
                             for k, v in row_map.iteritems():

--- a/codalab/apps/web/bundles.py
+++ b/codalab/apps/web/bundles.py
@@ -142,6 +142,11 @@ if len(settings.BUNDLE_SERVICE_URL) > 0:
                     if item['mode'] in ['html', 'contents']:
                         # item['name'] in ['stdout', 'stderr']
                         item['interpreted'] = map(base64.b64decode, item['interpreted'])
+                    elif item['mode'] == 'table':
+                        for row_map in item['interpreted'][1]:
+                            for k, v in row_map.iteritems():
+                                if v is None:
+                                     row_map[k] = 'MISSING'
                     elif 'bundle_info' in item:
                         for bundle_info in item['bundle_info']:
                             try:


### PR DESCRIPTION
If worksheet contains ``% display contents output-1`` directive that refers to a non-existent file or a column that refers to a non-existent file (using ``add output-1 output-1``) , this fix will just display 'MISSING' in web interface and would not give an internal 500 error.