### PR TITLE
autocomplete bundle info on name if in worksheet

### DIFF
--- a/codalab/apps/api/routers.py
+++ b/codalab/apps/api/routers.py
@@ -37,6 +37,7 @@ urlpatterns += (
     url(r'^worksheets/delete/$', views.WorksheetsDeleteApi.as_view(), name='api_worksheets_delete'),
     url(r'^worksheets/search/$', views.WorksheetsSearchApi.as_view(), name='api_worksheet_search'),
     url(r'^worksheets/get_uuid/$', views.WorksheetsGetUUIDApi.as_view(), name='api_worksheet_get_uuid'),
+    url(r'^worksheets/bundle_list/$', views.WorksheetsGetBundleListApi.as_view(), name='api_worksheet_bundle_list'),
     url(r'^worksheets/command/$', views.WorksheetsCommandApi.as_view(), name='api_worksheets_command'),
     url(r'^worksheets/(?P<uuid>[A-Za-z0-9]+)/$', views.WorksheetContentApi.as_view(), name='api_worksheet_content'),
     url(r'^bundles/content/(?P<uuid>[A-Za-z0-9]+)/$', views.BundleContentApi.as_view(), name='api_bundle_content'),

--- a/codalab/apps/api/routers.py
+++ b/codalab/apps/api/routers.py
@@ -43,6 +43,7 @@ urlpatterns += (
     url(r'^bundles/content/(?P<uuid>[A-Za-z0-9]+)/(?P<path>\S*)/$', views.BundleContentApi.as_view(), name='api_bundle_content'),
     url(r'^bundles/filecontent/(?P<uuid>[A-Za-z0-9]+)/(?P<path>\S*)/$', views.BundleFileContentApi.as_view(), name='api_bundle_filecontent'),
     url(r'^bundles/search/$', views.BundleSearchApi.as_view(), name='api_bundle_search'),
+    url(r'^bundles/get_uuid/$', views.BundleGetUUIDApi.as_view(), name='api_bundle_get_uuid'),
     url(r'^bundles/create/$', views.BundleCreateApi.as_view(), name='api_bundle_create'),
     url(r'^bundles/upload/$', views.BundleUploadApi.as_view(), name='api_bundle_upload'),
     url(r'^bundles/(?P<uuid>[A-Za-z0-9]+)/$', views.BundleInfoApi.as_view(), name='api_bundle_info'),

--- a/codalab/apps/api/views/worksheet_views.py
+++ b/codalab/apps/api/views/worksheet_views.py
@@ -381,7 +381,29 @@ class BundleSearchApi(views.APIView):
         service = BundleService(self.request.user)
         try:
             bundle_infos = service.search_bundles(search_string.split(' '), worksheet_uuid)
-            return Response(bundle_infos, content_type="application/json")
+            data = {
+                "bundles": bundle_infos,
+                "search_string": search_string
+            }
+            return Response(data, content_type="application/json")
+        except Exception as e:
+            tb = traceback.format_exc()
+            log_exception(self, e, tb)
+            return Response({"error": smart_str(e)}, status=500)
+
+class BundleGetUUIDApi(views.APIView):
+    """
+    Provides a web API to obtain a bundle's primary information.
+    """
+    def get(self, request):
+        user_id = self.request.user.id
+        bundle_spec = request.GET.get('spec', '')
+        worksheet_uuid = request.GET.get('worksheet_uuid', None)
+        logger.debug("BundleGetUUIDApi: user_id=%s; spec=%s. worksheet_uuid=%s", user_id, bundle_spec, worksheet_uuid)
+        service = BundleService(self.request.user)
+        try:
+            bundle_uuid = service.get_bundle_uuid(bundle_spec, worksheet_uuid)
+            return Response({'uuid': bundle_uuid}, content_type="application/json")
         except Exception as e:
             tb = traceback.format_exc()
             log_exception(self, e, tb)

--- a/codalab/apps/api/views/worksheet_views.py
+++ b/codalab/apps/api/views/worksheet_views.py
@@ -212,6 +212,23 @@ class WorksheetsGetUUIDApi(views.APIView):
             return Response({"error": smart_str(e)}, status=500)
 
 
+class WorksheetsGetBundleListApi(views.APIView):
+    """
+    Provides a web API to obtain a bundle's primary information.
+    """
+    def get(self, request):
+        user_id = self.request.user.id
+        worksheet_uuid = request.GET.get('worksheet_uuid', '')
+        logger.debug("WorksheetsGetBundleListApi: user_id=%s; worksheet_uuid=%s.", user_id, worksheet_uuid)
+        service = BundleService(self.request.user)
+        try:
+            bundle_list = service.get_worksheet_bundles(worksheet_uuid)
+            return Response({'bundles': bundle_list}, content_type="application/json")
+        except Exception as e:
+            tb = traceback.format_exc()
+            log_exception(self, e, tb)
+            return Response({"error": smart_str(e)}, status=500)
+
 
 class WorksheetContentApi(views.APIView):
     """

--- a/codalab/apps/web/bundles.py
+++ b/codalab/apps/web/bundles.py
@@ -100,10 +100,23 @@ if len(settings.BUNDLE_SERVICE_URL) > 0:
             uuid = None
             spec = smart_str(spec)  # generic clean up just in case
             try:
-                if(spec_util.UUID_REGEX.match(spec)):
+                if(spec_util.UUID_REGEX.match(spec)): # generic function sometimes get uuid already just return it.
                     uuid = spec
                 else:
                     uuid = worksheet_util.get_worksheet_uuid(self.client, None, spec)
+            except UsageError, e:
+                #TODO handle Found multiple worksheets with name
+                raise e
+            return uuid
+
+        def get_bundle_uuid(self, bundle_spec, worksheet_uuid=None):
+            uuid = None
+            spec = smart_str(spec)  # generic clean up just in case
+            try:
+                if(spec_util.UUID_REGEX.match(spec)):  # generic function sometimes get uuid already just return it.
+                    uuid = spec
+                else:
+                    uuid = worksheet_util.get_bundle_uuid(client, worksheet_uuid, bundle_spec)
             except UsageError, e:
                 #TODO handle Found multiple worksheets with name
                 raise e

--- a/codalab/apps/web/bundles.py
+++ b/codalab/apps/web/bundles.py
@@ -87,6 +87,14 @@ if len(settings.BUNDLE_SERVICE_URL) > 0:
             bundle_infos = self.client.get_bundle_infos(bundle_uuids)
             return bundle_infos
 
+        def get_worksheet_bundles(self, worksheet_uuid):
+            worksheet_info = self.client.get_worksheet_info(worksheet_uuid, True, True)
+            bundle_info_list = []
+            for (bundle_info, subworksheet_info, value_obj, item_type) in worksheet_info['items']:
+                if item_type == worksheet_util.TYPE_BUNDLE:
+                    bundle_info_list.append(bundle_info)
+            return bundle_info_list
+
         def worksheets(self):
             return _call_with_retries(lambda: self.client.list_worksheets())
 

--- a/codalab/apps/web/static/js/search/ws_actions.js
+++ b/codalab/apps/web/static/js/search/ws_actions.js
@@ -343,9 +343,6 @@ var WorksheetActions =  function() {
                     }else{
                         return defer.resolve([]); // return nothing they already have a bundle uuid
                     }
-                    if(search_string.indexOf('0x') === 0){ // checking if uuid
-                        worksheet_uuid = undefined; // they are searching bundles show all
-                    }
                     var get_data = {
                         search_string: search_string,
                         worksheet_uuid: worksheet_uuid
@@ -358,12 +355,10 @@ var WorksheetActions =  function() {
                         context: this,
                         success: function(data, status, jqXHR){
                             var autocomplete_list = [];
-                            console.log("info ajax success");
-                            console.log(data);
                             for(var uuid in data.bundles){
                                 var bundle = data.bundles[uuid];
-                                var user = bundle.owner_name; // owner is a string <username>(<user_id>)
-                                var created_date = new Date(0); // The 0 there is the key, which sets the date to the epoch
+                                var user = bundle.owner_name;  // owner is a string <username>(<user_id>)
+                                var created_date = new Date(0);  // The 0 there is the key, which sets the date to the epoch
                                 created_date.setUTCSeconds(bundle.metadata.created);
                                 created_date = created_date.toLocaleDateString() + " at " + created_date.toLocaleTimeString();
                                 var text = '';

--- a/codalab/apps/web/static/js/search/ws_actions.js
+++ b/codalab/apps/web/static/js/search/ws_actions.js
@@ -344,35 +344,33 @@ var WorksheetActions =  function() {
                         return defer.resolve([]); // return nothing they already have a bundle uuid
                     }
                     var get_data = {
-                        search_string: search_string,
                         worksheet_uuid: worksheet_uuid
                     };
+
                     $.ajax({
                         type: 'GET',
-                        url: '/api/bundles/search/',
+                        url: '/api/worksheets/bundle_list/',
                         dataType: 'json',
                         data: get_data,
-                        context: this,
                         success: function(data, status, jqXHR){
                             var autocomplete_list = [];
-                            for(var uuid in data.bundles){
-                                var bundle = data.bundles[uuid];
+                            data.bundles.forEach(function(bundle){
                                 var user = bundle.owner_name;  // owner is a string <username>(<user_id>)
                                 var created_date = new Date(0);  // The 0 there is the key, which sets the date to the epoch
                                 created_date.setUTCSeconds(bundle.metadata.created);
                                 created_date = created_date.toLocaleDateString() + " at " + created_date.toLocaleTimeString();
                                 var text = '';
-                                if(data.search_string.indexOf("0x") == 0){
-                                    text = uuid
+                                if(search_string.indexOf("0x") == 0){
+                                    text = bundle.uuid
                                 }else{ // search a word, lets match on that word
                                     text = bundle.metadata.name
-                                    self.temp_holder = uuid;
+                                    self.temp_holder = bundle.uuid;
                                 }
                                 autocomplete_list.push({
                                     'text': text,
-                                    'display':  uuid.slice(0, 10)  + " | " + bundle.metadata.name + ' | Owner: ' + user + ' | Created: ' + created_date,
+                                    'display':  bundle.uuid.slice(0, 10)  + " | " + bundle.metadata.name + ' | Owner: ' + user + ' | Created: ' + created_date,
                                 });
-                            }
+                            });  // end of forEach
                             defer.resolve(autocomplete_list)
                         },
                         error: function(jqHXR, status, error){

--- a/codalab/apps/web/static/js/worksheet/worksheet_action_bar.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_action_bar.js
@@ -13,14 +13,6 @@ var WorksheetActionBar = React.createClass({
     // ********************************************
     componentDidMount: function(){
         // https://github.com/jcubic/jquery.terminal
-        console.log("setting hight");
-        console.log("setting hight");
-        console.log("setting hight");
-        console.log("setting hight");
-        console.log("setting hight");
-        console.log("setting hight");
-        console.log("setting hight");
-        console.log("setting hight");
         var self = this;
         $('#dragbar_horizontal').mousedown(function(e){
             self.resizePanel(e);


### PR DESCRIPTION
While doing `cl info ` if you start to type a name of a bundle it will autocomplete for you. Else assumes you are doing a `cl search` and just looking at any and all bundles since names repeat outside of your worksheet..  Need some discussion about what the UX flow should be. 

![cl-info](https://cloud.githubusercontent.com/assets/123099/10125571/4c372a3c-652e-11e5-8af5-40219745fab1.gif)




issue: #1107