### PR TITLE
remove MISSING inconsistencies

### DIFF
--- a/codalab/apps/web/bundles.py
+++ b/codalab/apps/web/bundles.py
@@ -173,14 +173,14 @@ if len(settings.BUNDLE_SERVICE_URL) > 0:
                 for item in worksheet_info['items']:
                     if item['mode'] in ['html', 'contents']:
                         if item['interpreted'] is None:
-                            item['interpreted'] = ['MISSING']
+                            item['interpreted'] = [formatting.contents_str(item['interpreted'])]
                         else:
                             item['interpreted'] = map(base64.b64decode, item['interpreted'])
                     elif item['mode'] == 'table':
                         for row_map in item['interpreted'][1]:
                             for k, v in row_map.iteritems():
                                 if v is None:
-                                     row_map[k] = 'MISSING'
+                                     row_map[k] = formatting.contents_str(v)
                     elif 'bundle_info' in item:
                         infos = []
                         if isinstance(item['bundle_info'], list):


### PR DESCRIPTION
The following worksheet was used for testing

```
// Editing worksheet testground(0x6ba83eb905bb41aa8ee172da96038d70).
// https://github.com/codalab/codalab/wiki/User_Worksheet-Markdown
//
% schema s2
% add mem1 memory
% add mem2 memory size
% add mem3 memory %d
% add mem4 memory s/0/z
% add mem5 memory "%s | s/0/z"
% add |
% display table s2
[run sort-run -- sort.py:topological-sort.py,input:graph-1.txt : python sort.py < input > output]{0x8a5a3466bc0a4e64b6495f15c235b66b}

```
https://github.com/codalab/codalab/issues/1336: addresses MISSING inconsistencies
#### Manual Testing

###### all the columns now show MISSING (there are no inconsistencies)
![23](https://cloud.githubusercontent.com/assets/5567951/10799949/bdfe0fd6-7d6c-11e5-96f2-a2b7d7588875.png)

###### since now the MISSING word has been removed, all of these columns show empty
![24](https://cloud.githubusercontent.com/assets/5567951/10799948/bdfdbbb2-7d6c-11e5-89f8-f652e8f8a1ae.png)

###### The codebase no longer contains MISSING in various parts. If developer wants to change '' to something else, just go to formatting.contents_str() method and change the return value when the input_string is None. This ensures that the output is the same for all use-cases.
![25](https://cloud.githubusercontent.com/assets/5567951/10799946/bdf35b7c-7d6c-11e5-8caf-7f135c5b1223.png)

@percyliang @kashizui please review.