### PR TITLE
improve sign up experience

### DIFF
--- a/codalab/apps/web/templates/account/email/email_confirmation_message.txt
+++ b/codalab/apps/web/templates/account/email/email_confirmation_message.txt
@@ -1,0 +1,11 @@
+Hi {{ user }},
+
+You have signed up for an CodaLab account on {{ current_site }} using this
+email address.  To confirm and activate your account, please follow the link
+below:
+
+http://{{ current_site }}/accounts/confirm_email/{{ key }}/
+
+Enjoy!
+
+The CodaLab Team

--- a/codalab/apps/web/templates/account/email/email_confirmation_subject.txt
+++ b/codalab/apps/web/templates/account/email/email_confirmation_subject.txt
@@ -1,0 +1,1 @@
+Confirm email address for your CodaLab account

--- a/codalab/apps/web/templates/account/login.html
+++ b/codalab/apps/web/templates/account/login.html
@@ -63,9 +63,9 @@
             {% endif %}
             <button class="btn btn-primary margin-top" type="submit">{% trans "Sign In" %}</button>
         </form>
-        <p class="pad-top"><a href="{{ signup_url }}">Sign up for a new account</a></p>
-        <a href="../password/reset/">Forgot your password?</a></p>
-        <a href="" onclick="alert('Please wait 5 minutes and attempt logging in again to resend confirmation email.'); return false;">Resend confirmation email?</a>
+        <p>
+        <p><a href="../password/reset/">Forgot your password?</a></p>
+        <a href="" onclick="alert('Please wait 5 minutes and attempt logging in again to resend confirmation email.'); return false;">Resend confirmation email</a>
     </div>
 </div>
 {% endblock %}

--- a/codalab/apps/web/templates/account/signup.html
+++ b/codalab/apps/web/templates/account/signup.html
@@ -9,10 +9,6 @@
 {% block content %}
 <div class="row">
     <div class="col-md-6">
-	    <p>
-	        {% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in.</a>{% endblocktrans %}
-	    </p>
-
 	    <form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
 		    {% csrf_token %}
 
@@ -43,7 +39,7 @@
             </div>
 
             {% if redirect_field_value %}
-		      <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
+		          <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
             {% endif %}
             <button class="btn btn-primary margin-top" type="submit">{% trans "Sign Up" %}</button>
 	    </form>

--- a/codalab/apps/web/templates/base.html
+++ b/codalab/apps/web/templates/base.html
@@ -87,17 +87,6 @@
                             {% else %}
                                 <a href="/competitions/">Competitions</a>
                             {% endif %}
-                            <!--
-                            <ul class="dropdown-menu" role="menu">
-                                {% if user.is_authenticated %}
-                                    <li class="{% active request '/my/$' %}"><a href="/my">My CodaLab</a></li>
-                                    <li class="divider"></li>
-                                    <li><a href="{% url 'my_datasets' %}" tabIndex=4 target="_self">My Datasets</a></li>
-                                {% else %}
-                                    <li><a href="{% url 'account_login' %}" tabIndex=4 name="next" value="/my" target="_self">My CodaLab</a></li>
-                                {% endif %}
-                            </ul>
-                            -->
                         </li>
                         <li><a href="https://github.com/codalab/codalab/wiki" target="_blank">Help</a></li>
                         {% if user.is_authenticated %}
@@ -115,7 +104,10 @@
                             </li>
                         {% else %}
                             <li>
-                                <a href="{% url 'account_login' %}?next={{request.path}}" target="_self"><img src="{{ STATIC_URL }}img/icon_mini_avatar.png" class="mini-avatar" alt="Sign In"> Sign In</a>
+                                <a href="{% url 'account_signup' %}?next={{request.path}}" target="_self">Sign Up</a>
+                            </li>
+                            <li>
+                                <a href="{% url 'account_login' %}?next={{request.path}}" target="_self">Sign In</a>
                             </li>
                         {% endif %}
                     </ul>

--- a/codalab/apps/web/templates/web/my/settings.html
+++ b/codalab/apps/web/templates/web/my/settings.html
@@ -33,9 +33,10 @@
         </div>
     {% endif %}
 
+    <h3><b>Basic settings {% if user.is_staff %}<span class="label label-info">Staff</span>{% endif %}{% if user.is_superuser %} <span class="label label-success">Admin</span>{% endif %}</b></h3>
+
     <div class="row">
         <div class="col-sm-12">
-            <h4>Basic settings {% if user.is_staff %}<span class="label label-info">Staff</span>{% endif %}{% if user.is_superuser %} <span class="label label-success">Admin</span>{% endif %}</h4>
             <table class="table table-striped account">
                 <tbody>
                     <tr>
@@ -59,9 +60,10 @@
         </div>
     </div>
 
+    <h3><b>Competition settings</b></h3>
+
     <div class="row">
         <div class="col-sm-12">
-            <h4>Team</h4>
             <table class="table table-striped affiliation">
                 <tbody>
                     <tr>
@@ -79,8 +81,6 @@
 
     <div class="row">
         <div class="col-sm-12">
-
-            <h4>Competition settings</h4>
 
             <table class="table table-striped subscriptions">
                 <tbody>

--- a/codalab/apps/web/urls/my.py
+++ b/codalab/apps/web/urls/my.py
@@ -41,5 +41,7 @@ urlpatterns = patterns(
     url(r'^datasets/delete/(?P<pk>\d+)', views.OrganizerDataSetDelete.as_view(), name='my_datasets_delete'),
     url(r'^datasets/delete_multiple/', views.datasets_delete_multiple, name="datasets_delete_multiple"),
     url(r'^datasets/download/(?P<dataset_key>.+)', views.download_dataset, name='datasets_download'),
+
+    # User settings
     url(r'^settings/', views.UserSettingsView.as_view(), name='user_settings')
 )

--- a/codalab/apps/web/views.py
+++ b/codalab/apps/web/views.py
@@ -57,6 +57,9 @@ except ImportError:
 
 User = get_user_model()
 
+############################################################
+# General: template views
+
 class HomePageView(TemplateView):
     template_name = "web/index.html"
 
@@ -67,6 +70,22 @@ class HomePageView(TemplateView):
         context['worksheets'] = worksheets
         return context
 
+class LoginRequiredMixin(object):
+    @method_decorator(login_required)
+    def dispatch(self, *args, **kwargs):
+        return super(LoginRequiredMixin, self).dispatch(*args, **kwargs)
+
+class UserSettingsView(LoginRequiredMixin, UpdateView):
+    template_name = "web/my/settings.html"
+    form_class = forms.UserSettingsForm
+    model = User
+    success_url = "/my/settings/"
+
+    def get_object(self, queryset=None):
+        return self.request.user
+
+############################################################
+# Competitions: template views
 
 def competition_index(request):
     query = request.GET.get('q')
@@ -117,11 +136,6 @@ def sort_data_table(request, context, list):
     def sortkey(x):
         return x[order] if order in x and x[order] is not None else ''
     list.sort(key=sortkey, reverse=reverse)
-
-class LoginRequiredMixin(object):
-    @method_decorator(login_required)
-    def dispatch(self, *args, **kwargs):
-        return super(LoginRequiredMixin, self).dispatch(*args, **kwargs)
 
 #
 # Competition Views
@@ -1027,16 +1041,6 @@ class SubmissionDelete(LoginRequiredMixin, DeleteView):
             raise Http404()
 
         return obj
-
-
-class UserSettingsView(LoginRequiredMixin, UpdateView):
-    template_name = "web/my/settings.html"
-    form_class = forms.UserSettingsForm
-    model = User
-    success_url = "/my/settings/"
-
-    def get_object(self, queryset=None):
-        return self.request.user
 
 
 def download_dataset(request, dataset_key):


### PR DESCRIPTION
Make email confirmation more friendly / correct.  For local installations, need to set:

    from django.contrib.sites.models import Site
    site = Site.objects.all()[0]
    site.domain = site.name = '...'
    site.save()

Also, put the 'Sign Up' link on the front page so it's easier to sign up.

@pbhatnagar3: please take a look