### PR TITLE
fix when bundle that is focused on is deleted, the app does not freakout

### DIFF
--- a/codalab/apps/api/views/worksheet_views.py
+++ b/codalab/apps/api/views/worksheet_views.py
@@ -273,6 +273,8 @@ class BundleInfoApi(views.APIView):
         service = BundleService(self.request.user)
         try:
             bundle_info = service.get_bundle_info(uuid)
+            if bundle_info is None:
+                return Response({'error': 'The bundle is not availble'})
             bundle_info.update(service.get_bundle_contents(uuid))
             return Response(bundle_info, content_type="application/json")
         except Exception as e:

--- a/codalab/apps/web/bundles.py
+++ b/codalab/apps/web/bundles.py
@@ -65,6 +65,8 @@ if len(settings.BUNDLE_SERVICE_URL) > 0:
         def get_bundle_info(self, uuid):
             bundle_info = _call_with_retries(lambda: self.client.get_bundle_info(uuid, True, True, True))
 
+            if bundle_info is None:
+                return None
             # Set permissions
             bundle_info['edit_permission'] = (bundle_info['permission'] == GROUP_OBJECT_PERMISSION_ALL)
             # Format permissions into strings

--- a/codalab/apps/web/static/js/worksheet/worksheet_side_panel.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_side_panel.js
@@ -34,9 +34,11 @@ var WorksheetSidePanel = React.createClass({
 
     getFocus: function() {
         // Return the state to show on the side panel
-        if (this.props.focusIndex == -1)
+        var focusedBunble = this.props.ws.state.items[this.props.focusIndex]
+        if (this.props.focusIndex == -1 || focusedBunble === undefined) {
           return this.props.ws.state;  // Show current worksheet
-        return this.props.ws.state.items[this.props.focusIndex].state;
+        }
+        return focusedBunble.state;
     },
 
     // What kind of thing is it?


### PR DESCRIPTION
#### Testing
#### selenium  tests
all pass
#### manual testing
 ###### with worksheet item
![111](https://cloud.githubusercontent.com/assets/5567951/11013848/4f3693d4-84d3-11e5-93b7-5050fbb60afc.png)
![112](https://cloud.githubusercontent.com/assets/5567951/11013849/4f36a3ba-84d3-11e5-85e9-dae5d7c527c7.png)
^ we delete the only item in the table and there is no error
![113](https://cloud.githubusercontent.com/assets/5567951/11013850/4f378406-84d3-11e5-86ba-4d425dccb3df.png)
^ nothing in the console freaks out

###### with multiple items
![114](https://cloud.githubusercontent.com/assets/5567951/11013853/76800916-84d3-11e5-8da9-d8a81496ac49.png)
![115](https://cloud.githubusercontent.com/assets/5567951/11013854/7bc443c4-84d3-11e5-96fa-a66a804dcd53.png)

@percyliang @kashizui please review. 
