### PR TITLE
'u' pastes uuid and 'a' pastes args into console.

### DIFF
--- a/codalab/apps/web/static/js/worksheet/table_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/table_bundle_interface.js
@@ -46,8 +46,8 @@ var TableBundle = React.createClass({
         // Paste args of focused bundle into console
         Mousetrap.bind(['a'], function(e) {
             var bundleInfo = this.refs['row' + this.state.rowFocusIndex].props.bundleInfo;
-            if (bundleInfo.command != null) {
-                $('#command_line').terminal().insert(bundleInfo.command);
+            if (bundleInfo.args != null) {
+                $('#command_line').terminal().insert(bundleInfo.args);
             }
         }.bind(this), 'keydown');
     },

--- a/codalab/apps/web/static/js/worksheet/table_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/table_bundle_interface.js
@@ -32,11 +32,20 @@ var TableBundle = React.createClass({
             else
               this.focusOnRow(newIndex);
         }.bind(this), 'keydown');
+
+        Mousetrap.bind(['enter'], function(e) {
+            window.open(this.refs['row' + this.state.rowFocusIndex].props.url, '_blank');
+        }.bind(this), 'keydown');
+
+        // Paste uuid of focused bundle into console
+        Mousetrap.bind(['t'], function(e) {
+            var uuid = this.refs['row' + this.state.rowFocusIndex].props.uuid;
+            $('#command_line').terminal().insert(uuid);
+        }.bind(this), 'keydown');
     },
 
     scrollToRow: function(index) {
         var __innerScrollToRow = function(index) {
-            //console.log('__innerScrollToRow', index);
             // Compute the current position of the focused row.
             var node = this.getDOMNode();
             var nodePos = node.getBoundingClientRect();
@@ -64,8 +73,6 @@ var TableBundle = React.createClass({
     },
 
     render: function() {
-        //console.log('TableBundle.render', this.state.rowFocusIndex);
-
         if (this.props.active && this.props.focused)
           this.capture_keys();
 
@@ -84,10 +91,10 @@ var TableBundle = React.createClass({
         var focusIndex = this.state.rowFocusIndex;
         var row_items = item.interpreted[1];  // Array of {header: value, ...} objects
         var column_with_hyperlinks = [];
-        (Object.keys(row_items[0])).forEach(function(x) {
+        Object.keys(row_items[0]).forEach(function(x) {
             if (row_items[0][x] && row_items[0][x]['path'])
                 column_with_hyperlinks.push(x);
-        })
+        });
         var body_rows_html = row_items.map(function(row_item, index) {
             var row_ref = 'row' + index;
             var rowFocused = self.props.focused && (index == focusIndex);
@@ -136,20 +143,9 @@ var TableRow = React.createClass({
         this.props.handleClick(this.props.index);
     },
 
-    capture_keys: function() {
-        Mousetrap.bind(['enter'], function(e) {
-            window.open(this.props.url, '_blank');
-        }.bind(this), 'keydown');
-    },
-
     render: function() {
-        //console.log('TableRow.render', this.props.focused);
-        if (this.props.focused)
-          this.capture_keys();
-
         var focusedClass = this.props.focused ? 'focused' : '';
         var row_items = this.props.item;
-        var header_items = this.props.headerItems;
         var column_classes = this.props.columnClasses;
         var base_url = this.props.url;
         var uuid = this.props.uuid;

--- a/codalab/apps/web/static/js/worksheet/table_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/table_bundle_interface.js
@@ -38,9 +38,17 @@ var TableBundle = React.createClass({
         }.bind(this), 'keydown');
 
         // Paste uuid of focused bundle into console
-        Mousetrap.bind(['t'], function(e) {
+        Mousetrap.bind(['u'], function(e) {
             var uuid = this.refs['row' + this.state.rowFocusIndex].props.uuid;
             $('#command_line').terminal().insert(uuid);
+        }.bind(this), 'keydown');
+
+        // Paste args of focused bundle into console
+        Mousetrap.bind(['a'], function(e) {
+            var bundleInfo = this.refs['row' + this.state.rowFocusIndex].props.bundleInfo;
+            if (bundleInfo.command != null) {
+                $('#command_line').terminal().insert(bundleInfo.command);
+            }
         }.bind(this), 'keydown');
     },
 
@@ -106,6 +114,7 @@ var TableBundle = React.createClass({
                      index={index}
                      focused={rowFocused}
                      url={url}
+                     bundleInfo={bundle_info[index]}
                      uuid={bundle_info[index].uuid}
                      headerItems={header_items}
                      columnClasses={column_classes}

--- a/codalab/apps/web/static/js/worksheet/table_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/table_bundle_interface.js
@@ -41,6 +41,7 @@ var TableBundle = React.createClass({
         Mousetrap.bind(['u'], function(e) {
             var uuid = this.refs['row' + this.state.rowFocusIndex].props.uuid;
             $('#command_line').terminal().insert(uuid);
+            this.props.focusActionBar();
         }.bind(this), 'keydown');
 
         // Paste args of focused bundle into console
@@ -48,6 +49,7 @@ var TableBundle = React.createClass({
             var bundleInfo = this.refs['row' + this.state.rowFocusIndex].props.bundleInfo;
             if (bundleInfo.args != null) {
                 $('#command_line').terminal().insert(bundleInfo.args);
+                this.props.focusActionBar();
             }
         }.bind(this), 'keydown');
     },

--- a/codalab/apps/web/static/js/worksheet/worksheet_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_bundle_interface.js
@@ -32,6 +32,17 @@ var WorksheetBundle = React.createClass({
             else
               this.focusOnRow(newIndex);
         }.bind(this), 'keydown');
+
+        // Open worksheet in new window/tab
+        Mousetrap.bind(['enter'], function(e) {
+            window.open(this.refs['row' + this.state.rowFocusIndex].props.url, '_blank');
+        }.bind(this), 'keydown');
+
+        // Paste uuid of focused worksheet into console
+        Mousetrap.bind(['t'], function(e) {
+            var uuid = this.refs['row' + this.state.rowFocusIndex].props.uuid;
+            $('#command_line').terminal().insert(uuid);
+        }.bind(this), 'keydown');
     },
 
     scrollToRow: function(index) {
@@ -123,17 +134,7 @@ var TableWorksheetRow = React.createClass({
       this.props.handleClick(this.props.index);
     },
 
-    capture_keys: function() {
-        Mousetrap.bind(['enter'], function(e) {
-            window.open(this.props.url, '_blank');
-        }.bind(this), 'keydown');
-    },
-
     render: function() {
-        //console.log('TableRow.render', this.props.focused);
-        if (this.props.focused)
-          this.capture_keys();
-
         var item = this.props.item.interpreted;
         var className = /*'type-worksheet' + */(this.props.focused ? ' focused' : '');
         var ws_url = '/worksheets/' + item.uuid;

--- a/codalab/apps/web/static/js/worksheet/worksheet_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_bundle_interface.js
@@ -42,6 +42,7 @@ var WorksheetBundle = React.createClass({
         Mousetrap.bind(['u'], function(e) {
             var uuid = this.refs['row' + this.state.rowFocusIndex].props.uuid;
             $('#command_line').terminal().insert(uuid);
+            this.props.focusActionBar();
         }.bind(this), 'keydown');
     },
 

--- a/codalab/apps/web/static/js/worksheet/worksheet_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_bundle_interface.js
@@ -39,7 +39,7 @@ var WorksheetBundle = React.createClass({
         }.bind(this), 'keydown');
 
         // Paste uuid of focused worksheet into console
-        Mousetrap.bind(['t'], function(e) {
+        Mousetrap.bind(['u'], function(e) {
             var uuid = this.refs['row' + this.state.rowFocusIndex].props.uuid;
             $('#command_line').terminal().insert(uuid);
         }.bind(this), 'keydown');

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.js
@@ -96,7 +96,6 @@ var Worksheet = React.createClass({
     capture_keys: function() {
         Mousetrap.reset();  // reset, since we will call children, let's start fresh.
 
-        var activeComponent = this.refs[this.state.activeComponent];
         if (this.state.activeComponent == 'action') {
             // no need for other keys, we have the action bar focused
             return;
@@ -120,7 +119,7 @@ var Worksheet = React.createClass({
             }
         });
 
-        Mousetrap.bind(['shift+r',], function(e) {
+        Mousetrap.bind(['shift+r'], function(e) {
             this.refreshWorksheet();
             return false;
         }.bind(this));

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.js
@@ -131,9 +131,7 @@ var Worksheet = React.createClass({
 
         // Focus on web terminal (action bar)
         Mousetrap.bind(['c'], function(e) {
-            this.showActionBar();
-            this.setState({activeComponent: 'action'});
-            $('#command_line').terminal().focus();
+            this.focusActionBar();
         }.bind(this));
 
         // Toggle edit mode
@@ -167,11 +165,10 @@ var Worksheet = React.createClass({
     toggleActionBar: function() {
         this.setState({showActionBar: !this.state.showActionBar});
     },
-    showActionBar: function() {
+    focusActionBar: function() {
+        this.setState({activeComponent: 'action'});
         this.setState({showActionBar: true});
-    },
-    hideActionBar: function() {
-        this.setState({showActionBar: false});
+        $('#command_line').terminal().focus();
     },
     refreshWorksheet: function() {
         $('#update_progress').show();
@@ -257,12 +254,10 @@ var Worksheet = React.createClass({
         var rawWorksheet = info && info.raw.join('\n');
         var editPermission = info && info.edit_permission;
         var canEdit = this.canEdit() && this.state.editMode;
-        var checkboxEnabled = this.state.checkboxEnabled;
 
         var searchClassName     = !this.state.showActionBar ? 'search-hidden' : '';
         var editableClassName   = canEdit ? 'editable' : '';
         var viewClass           = !canEdit && !this.state.editMode ? 'active' : '';
-        var editClass           = canEdit && !this.state.editMode ? 'active' : '';
         var rawClass            = this.state.editMode ? 'active' : '';
 
         var sourceStr = editPermission ? 'Edit source' : 'View source';
@@ -322,6 +317,7 @@ var Worksheet = React.createClass({
                     updateWorksheetFocusIndex={this._setfocusIndex}
                     updateWorksheetSubFocusIndex={this._setWorksheetSubFocusIndex}
                     refreshWorksheet={this.refreshWorksheet}
+                    focusActionBar={this.focusActionBar}
                 />
             );
 

--- a/codalab/apps/web/static/js/worksheet/worksheet_items.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_items.js
@@ -79,7 +79,6 @@ var WorksheetItemList = React.createClass({
         var info = this.props.ws.info;
         if (index < -1 || index >= info.items.length)
           return;  // Out of bounds (note -1 is okay)
-        //console.log('WorksheetItemList.setFocus', index, subIndex);
 
         this.setState({focusIndex: index});
         this.props.updateWorksheetFocusIndex(index);  // Notify parent of selection (so we can show the right thing on the side panel)
@@ -147,10 +146,11 @@ var WorksheetItemList = React.createClass({
                   focused: focused,
                   canEdit: canEdit,
                   setFocus: setFocus,
-                  updateWorksheetSubFocusIndex: updateWorksheetSubFocusIndex
+                  updateWorksheetSubFocusIndex: updateWorksheetSubFocusIndex,
+                  focusActionBar: this.props.focusActionBar
                 };
                 addWorksheetItems(props, worksheet_items);
-            });
+            }.bind(this));
             items_display = worksheet_items;
         } else {
           items_display = <p className="empty-worksheet">(empty)</p>;
@@ -223,4 +223,4 @@ var addWorksheetItems = function(props, worksheet_items) {
       );
     }
     worksheet_items.push(elem);
-}
+};

--- a/codalab/apps/web/static/js/worksheet/ws_mixins.js
+++ b/codalab/apps/web/static/js/worksheet/ws_mixins.js
@@ -13,7 +13,7 @@ var GoToBundleMixin = {
     capture_keys: function(e){
          Mousetrap.bind(['enter'], function(e){
             this.goToBundlePage();
-        }.bind(this), 'keydown');
+         }.bind(this), 'keydown');
     },
     goToBundlePage: function(){
         var bundleUUID = this.props.item.bundle_info.uuid;

--- a/codalab/apps/web/templates/web/worksheets/detail.html
+++ b/codalab/apps/web/templates/web/worksheets/detail.html
@@ -70,7 +70,10 @@
                       <td><kbd>enter</kbd></td><td>Open current bundle or worksheet</td>
                     </tr>
                     <tr>
-                        <td><kbd>t</kbd></td><td>Paste UUID of current bundle or worksheet into console</td>
+                        <td><kbd>u</kbd></td><td>Paste UUID of current bundle or worksheet into console</td>
+                    </tr>
+                    <tr>
+                        <td><kbd>a</kbd></td><td>Paste run arguments of current bundle into console</td>
                     </tr>
                     <tr>
                       <td><kbd>?</kbd></td><td>Show keyboard shortcut help</td>

--- a/codalab/apps/web/templates/web/worksheets/detail.html
+++ b/codalab/apps/web/templates/web/worksheets/detail.html
@@ -70,6 +70,9 @@
                       <td><kbd>enter</kbd></td><td>Open current bundle or worksheet</td>
                     </tr>
                     <tr>
+                        <td><kbd>t</kbd></td><td>Paste UUID of current bundle or worksheet into console</td>
+                    </tr>
+                    <tr>
                       <td><kbd>?</kbd></td><td>Show keyboard shortcut help</td>
                     </tr>
                 </table>

--- a/codalab/apps/web/templates/web/worksheets/detail.html
+++ b/codalab/apps/web/templates/web/worksheets/detail.html
@@ -70,10 +70,10 @@
                       <td><kbd>enter</kbd></td><td>Open current bundle or worksheet</td>
                     </tr>
                     <tr>
-                        <td><kbd>u</kbd></td><td>Paste UUID of current bundle or worksheet into console</td>
+                        <td><kbd>u</kbd></td><td>Paste UUID of current bundle or worksheet into web terminal</td>
                     </tr>
                     <tr>
-                        <td><kbd>a</kbd></td><td>Paste run arguments of current bundle into console</td>
+                        <td><kbd>a</kbd></td><td>Paste arguments to recreate current bundle into web terminal</td>
                     </tr>
                     <tr>
                       <td><kbd>?</kbd></td><td>Show keyboard shortcut help</td>


### PR DESCRIPTION
 - `u` pastes uuid of focused bundle or worksheet into console
 - `a` pastes args of focused bundle if available
 - consolidated some key binding code (decided to go this route because alternative was the pass `activeComponent` as an additional prop to each of the table rows.

(apologies for potentially hacky looking code, in general really itching to make all this code organized better but I don't even know where to start. perhaps from the leaf nodes of the react component graph.)

Fixes #1376 

@percyliang @pbhatnagar3 please review