### PR TITLE
Escape HTML in contents bundle

### DIFF
--- a/codalab/apps/web/static/js/worksheet/contents_bundle_interface.js
+++ b/codalab/apps/web/static/js/worksheet/contents_bundle_interface.js
@@ -16,7 +16,7 @@ var ContentsBundle = React.createClass({
             <div className="ws-item" onClick={this.handleClick}>
                 <div className={className} ref={this.props.item.ref}>
                     <blockquote>
-                        <p dangerouslySetInnerHTML={{__html: contents}} />
+                        <p>{contents}</p>
                     </blockquote>
                 </div>
             </div>


### PR DESCRIPTION
Let React escape any content that gets displayed in a `% display contents` bundle.

Helps fix #1423 

@percyliang please review