### PR TITLE
check authentication before editing title and name

### DIFF
--- a/codalab/apps/web/static/css/imports.css
+++ b/codalab/apps/web/static/css/imports.css
@@ -8780,8 +8780,11 @@ fieldset[disabled] #worksheet-list .worksheet-tile .worksheet-inner button.delet
 }
 .editable-field:hover {
     cursor: text;
-     border-radius: 4px;
+    border-radius: 4px;
     box-shadow: 1px 1px 1px 1px grey;
+}
+.editable-error-block {
+  font-size: 16px;
 }
 #worksheet-editor {
         margin: 0;

--- a/codalab/apps/web/static/js/worksheet/worksheet_interface.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_interface.js
@@ -106,8 +106,8 @@ var Worksheet = React.createClass({
              return JSON.stringify(data);
             }.bind(this),
             success: function(response, newValue) {
-                if (response.error) {
-                    return response.error;
+                if (response.exception) {
+                    return response.exception;
                 }
                 this.state.ws.fetch({async: false});
             }.bind(this)
@@ -375,6 +375,7 @@ var Worksheet = React.createClass({
 
         var searchClassName   = !this.state.showActionBar ? 'search-hidden' : '';
         var editableClassName = canEdit ? 'editable' : '';
+        var editableFieldName = this.canEdit() ? 'editable-field' : '';
         var viewClass         = !canEdit && !this.state.editMode ? 'active' : '';
         var rawClass          = this.state.editMode ? 'active' : '';
 
@@ -471,10 +472,10 @@ var Worksheet = React.createClass({
                             <div id="worksheet_content" className={editableClassName}>
                                 <div className="header-row">
                                     <div className="row">
-                                        <h4 className='worksheet-title'><a href="#" id='title' className='editable-field' data-value={info && info.title} data-type="text" data-url="/api/worksheets/command/">{info && info.title}</a></h4>
+                                        <h4 className='worksheet-title'><a href="#" id='title' className={editableFieldName} data-value={info && info.title} data-type="text" data-url="/api/worksheets/command/">{info && info.title}</a></h4>
                                         <div className="col-sm-6 col-md-8">
                                             <div className="worksheet-name">
-                                                <div className="worksheet-detail"><b>name: </b><a href="#" id='name' className='editable-field' data-value={info && info.name} data-type="text" data-url="/api/worksheets/command/">{info && info.name}</a></div>
+                                                <div className="worksheet-detail"><b>name: </b><a href="#" id='name' className={editableFieldName} data-value={info && info.name} data-type="text" data-url="/api/worksheets/command/">{info && info.name}</a></div>
                                                 <div className="worksheet-detail"><b>uuid: </b>{info && info.uuid}</div>
                                                 <div className="worksheet-detail"><b>owner: </b>{info && info.owner_name}</div>
                                                 <div className="worksheet-detail"><b>permissions: </b>{info && render_permissions(info)}</div>


### PR DESCRIPTION
fixes #1429 #1369 
 
Earlier, since the code checked for response.error and not response.exception, there was no error being thrown. When that was changed, the error that was thrown looked non-ideal.
![00001](https://cloud.githubusercontent.com/assets/5567951/11524302/9f5e59dc-987e-11e5-863d-df4bd1d9371a.png)

- made changes to the css to make sure that the error looks more readable now. 
![0000](https://cloud.githubusercontent.com/assets/5567951/11524315/b29968c0-987e-11e5-804a-811df19c9dda.png)

This was done as a precautionary measure that if ever, while editing the name or the title, an error happens, then the user should be able to read it.

also added a authentication check before allowing user to edit the name/title of worksheet. If the user has permission, worksheet looks like this:

![0002](https://cloud.githubusercontent.com/assets/5567951/11524367/25886340-987f-11e5-9204-d65b5f2f19f4.png)

else the worksheet looks like this (the title is no longer allowed to be edited)
![004](https://cloud.githubusercontent.com/assets/5567951/11524373/348cbe4a-987f-11e5-9cc6-8cf19359ceb3.png)

@percyliang @kashizui please review.

