### PR TITLE
ace editor readonly when no permissions to edit

### DIFF
--- a/codalab/apps/web/static/css/imports.css
+++ b/codalab/apps/web/static/css/imports.css
@@ -8017,7 +8017,7 @@ fieldset[disabled] #worksheet_content .header-row .controls .edit-features .btn-
   pointer-events: none;
   -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=65)";
   filter: alpha(opacity=65);
-  opacity: 0.65;
+  background-color: #A9A9A9;
   -webkit-box-shadow: none;
   box-shadow: none;
 }
@@ -8039,24 +8039,6 @@ fieldset[disabled] #worksheet_content .header-row .controls .edit-features .btn-
 #worksheet_content .header-row .controls .edit-features .btn-group button.active,
 .open > .dropdown-toggle#worksheet_content .header-row .controls .edit-features .btn-group button {
   background-image: none;
-}
-#worksheet_content .header-row .controls .edit-features .btn-group button.disabled,
-#worksheet_content .header-row .controls .edit-features .btn-group button[disabled],
-fieldset[disabled] #worksheet_content .header-row .controls .edit-features .btn-group button,
-#worksheet_content .header-row .controls .edit-features .btn-group button.disabled:hover,
-#worksheet_content .header-row .controls .edit-features .btn-group button[disabled]:hover,
-fieldset[disabled] #worksheet_content .header-row .controls .edit-features .btn-group button:hover,
-#worksheet_content .header-row .controls .edit-features .btn-group button.disabled:focus,
-#worksheet_content .header-row .controls .edit-features .btn-group button[disabled]:focus,
-fieldset[disabled] #worksheet_content .header-row .controls .edit-features .btn-group button:focus,
-#worksheet_content .header-row .controls .edit-features .btn-group button.disabled:active,
-#worksheet_content .header-row .controls .edit-features .btn-group button[disabled]:active,
-fieldset[disabled] #worksheet_content .header-row .controls .edit-features .btn-group button:active,
-#worksheet_content .header-row .controls .edit-features .btn-group button.disabled.active,
-#worksheet_content .header-row .controls .edit-features .btn-group button[disabled].active,
-fieldset[disabled] #worksheet_content .header-row .controls .edit-features .btn-group button.active {
-  background-color: #fafafa;
-  border-color: #ccc;
 }
 #worksheet_content .header-row .controls .edit-features .btn-group button .badge {
   color: #fafafa;


### PR DESCRIPTION
#1460 
Earlier, even when the user did not have permissions to edit the worksheet, they could go into the editing mode and start making changes (although they were not allowed to make safe those changes). Now the editor goes into the 'readonly' mode where they can see the raw worksheet but cannot make any edits. 
@percyliang @kashizui please review.

NOTE: When the user does not have permissions, the safe button is 'disabled'. However, the way CSS is written for group-btn is making it nearly impossible to make the safe button have gray background. (see the screenshot). I spent some time trying to fix this but could not. I will tackle other issues first and then come back to this CSS issue.

![y_u_css](https://cloud.githubusercontent.com/assets/5567951/11550042/86bb9744-9920-11e5-8ef8-432353a84575.png)

UPDATE: 
The css is fixed now. I have gutted out the css that was duplicate and was causing issues:
![css_works](https://cloud.githubusercontent.com/assets/5567951/11550451/e8cf7fd2-9924-11e5-9500-2be7a644d345.png)
