### PR TITLE
add description below name in side-panel for bundles

### DIFF
--- a/codalab/apps/api/views/worksheet_views.py
+++ b/codalab/apps/api/views/worksheet_views.py
@@ -275,7 +275,7 @@ class BundleInfoApi(views.APIView):
 
                 # TODO: do this generally based on the CLI specs.
                 # Remove generated fields.
-                for key in ['data_size', 'created', 'time', 'memory', 'exitcode', 'actions']:
+                for key in ['data_size', 'created', 'time', 'memory', 'exitcode', 'actions', 'started', 'last_updated']:
                     if key in new_metadata:
                         del new_metadata[key]
 

--- a/codalab/apps/web/static/css/imports.css
+++ b/codalab/apps/web/static/css/imports.css
@@ -7804,7 +7804,7 @@ body,
   text-overflow: ellipsis;
 }
 #worksheet .ws-panel #panel_content .bundle-description {
-  font-size: 90%;
+  font-size: 16px;
   margin: 5px 0;
 }
 #worksheet .ws-panel #panel_content h3 {

--- a/codalab/apps/web/static/js/worksheet/worksheet_side_panel.js
+++ b/codalab/apps/web/static/js/worksheet/worksheet_side_panel.js
@@ -408,11 +408,17 @@ function renderHeader(bundle_info) {
   var bundle_url = '/bundles/' + bundle_info.uuid;
   var bundle_download_url = "/bundles/" + bundle_info.uuid + "/download";
   var bundle_name;
+  var bundle_description;
   if (bundle_info.metadata.name) {
-    bundle_name = <h3 className="bundle-name"><a href="#" id='name' className='editable-field' data-value={bundle_info.metadata.name} data-type="text" data-url={"/api/bundles/"+bundle_info.uuid+"/"}>{bundle_info.metadata.name}</a></h3>
+    if (bundle_info.edit_permission) {
+      bundle_name = <h3 className="bundle-name"><a href="#" id='name' className='editable-field' data-value={bundle_info.metadata.name} data-type="text" data-url={"/api/bundles/"+bundle_info.uuid+"/"}>{bundle_info.metadata.name}</a></h3>;
+      bundle_description = <h3 className="bundle-description">Description: <a href="#" className="editable-field" id={'description'} data-value={bundle_info.metadata.description} data-type="text" data-url={"/api/bundles/"+bundle_info.uuid+"/"}>{bundle_info.metadata.description}</a></h3>;
+    } else {
+      bundle_name = <h3 className="bundle-name">{bundle_info.metadata.name}</h3>;
+      bundle_description = <h3 className="bundle-description">Description: {bundle_info.metadata.description}</h3>;
+    }
   }
   var bundle_state_class = 'bundle-state state-' + (bundle_info.state || 'ready');
-  var bundle_description = bundle_info.metadata.description ? <p className="bundle-description">{bundle_info.metadata.description}</p> : ''
 
   // Display basic information
   function createRow(key, value) {


### PR DESCRIPTION
fixes #1411 

Now, you can see the description under the name for bundles. And users can click on it to make edits if they have permissions.
@percyliang @kashizui please review.

#### with permissions:
![editable](https://cloud.githubusercontent.com/assets/5567951/11552424/4847e03a-9939-11e5-9e30-fdaeb4caf4ab.png)
#### without permissions:
![non-editable](https://cloud.githubusercontent.com/assets/5567951/11552435/5fbadd58-9939-11e5-9d0c-e539dcdabb98.png)
