### PR TITLE
manually fix imports.css

### DIFF
--- a/codalab/apps/web/static/css/imports.css
+++ b/codalab/apps/web/static/css/imports.css
@@ -7458,9 +7458,36 @@ input[type="checkbox"] {
 .already-disliked {
   color: red;
 }
+/* MANUALLY ADDED
+TODO: add this to LESS;
+************************/
+.editable-field:hover {
+    cursor: text;
+    border-radius: 4px;
+    box-shadow: 1px 1px 1px 1px grey;
+}
+.editable-error-block {
+  font-size: 16px
+}
+#worksheet-editor {
+        margin: 0
+        position: relative;
+        top: 0;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        width: 1000px;
+        height: 700px;
+}
+.frontpage_code {
+  font-family: monospace;
+  font-size: 14px;
+  color: #33aa33;
+}
+/*************************/
 /* Everything below correspondes to the latest homepage*/
 .col-sm-6 .btn-group .btn-group a {
-  color: #FFFFFF;
+  color: #777777;
   font-weight: bold;
   font-size: 18px;
 }


### PR DESCRIPTION
 manually fixed imports.css to enable functionality for ace-editor, x-editable. The buttons are fixed and green font is back on the front-page.

@percyliang @kashizui @FlavioAlexander